### PR TITLE
fix the failing Semgrep test in incorrect-unsigned-comparison

### DIFF
--- a/c/incorrect-unsigned-comparison.yaml
+++ b/c/incorrect-unsigned-comparison.yaml
@@ -1,5 +1,5 @@
 rules:
-  - id: raptor-incorrect-unsigned-comparison.yaml
+  - id: raptor-incorrect-unsigned-comparison
     metadata:
       author: Marco Ivaldi <raptor@0xdeadbeef.info>
       references:


### PR DESCRIPTION
Thanks for the great rules.

One Semgrep test was failing because the ruleid had `.yaml` in the end.

There are a bunch of more test failing because the test comments contain `(probably)`.

For example, in `c/insecure-api-scanf-etc.c` we see 

```c
	// ok: raptor-insecure-api-scanf-etc (probably)
	scanf("%d", &number);
```

This is failing the test because there's no ruleid `raptor-insecure-api-scanf-etc (probably)`. I did not want to remove the comments in case you wanted to do something else with them.

```
Found rule id mismatch - file=c/insecure-api-scanf-etc.c 'ruleid' annotation with no
YAML rule={'raptor-insecure-api-scanf-etc (probably)'}
Failing due to rule id mismatch. There is a test denoted with
'ruleid: <rule name>' where the rule name does not exist or is not expected in the test file.
```

You can run the tests all rules by running `semgrep --test` in the root of the repository.