### PR TITLE
fix: broaden unsigned comparison rule and avoid cast false positives

### DIFF
--- a/rules/c/incorrect-unsigned-comparison.c
+++ b/rules/c/incorrect-unsigned-comparison.c
@@ -1,6 +1,8 @@
 // Marco Ivaldi <raptor@0xdeadbeef.info>
 
 #include <stdio.h>
+#include <stdint.h>
+#include <limits.h>
 
 int bad1()
 {
@@ -30,6 +32,29 @@ int good1()
 
 	// ok: raptor-incorrect-unsigned-comparison
 	if (uvar > 0)
+		return 1;
+
+	return 0;
+}
+
+struct Context {
+	uint64_t l_qseq;
+};
+
+int bad_mixed(struct Context *c, int new_l_data)
+{
+	// ruleid: raptor-incorrect-unsigned-comparison
+	if (new_l_data > INT_MAX || (uint64_t)c->l_qseq < 0)
+		return 1;
+
+	return 0;
+}
+
+int good2()
+{
+	size_t uvar;
+	// ok
+	if ((int32_t)uvar >= 0)
 		return 1;
 
 	return 0;

--- a/rules/c/incorrect-unsigned-comparison.yaml
+++ b/rules/c/incorrect-unsigned-comparison.yaml
@@ -26,27 +26,13 @@ rules:
     languages:
       - c
       - cpp
-    # NOTE: some types are not covered.
     # NOTE: incorrect unsigned assigments are not covered.
-    pattern-either:
-      # < (always false)
-      - pattern: (unsigned short $_) < 0
-      - pattern: (unsigned short int $_) < 0
-      - pattern: (unsigned int $_) < 0
-      - pattern: (unsigned long $_) < 0
-      - pattern: (unsigned long int $_) < 0
-      - pattern: (size_t $_) < 0
-      # <=
-      - pattern: (unsigned short $_) <= 0
-      - pattern: (unsigned short int $_) <= 0
-      - pattern: (unsigned int $_) <= 0
-      - pattern: (unsigned long $_) <= 0
-      - pattern: (unsigned long int $_) <= 0
-      - pattern: (size_t $_) <= 0
-      # >= (always true)
-      - pattern: (unsigned short $_) >= 0
-      - pattern: (unsigned short int $_) >= 0
-      - pattern: (unsigned int $_) >= 0
-      - pattern: (unsigned long $_) >= 0
-      - pattern: (unsigned long int $_) >= 0
-      - pattern: (size_t $_) >= 0
+    patterns:
+      - pattern-either:
+          - pattern: ($UT $E) < $BEZ
+          - pattern: ($UT $E) <= $BEZ
+          - pattern: ($UT $E) >= $BEZ
+      - pattern-not: ($ST) ($UT $E) >= 0
+      - metavariable-regex:
+          metavariable: $UT
+          regex: unsigned\s+(char|short|short\s+int|int|long|long\s+int)|uint(8|16|32|64)_t|size_t|uintptr_t


### PR DESCRIPTION
This PR make changes on:

1. Catch additional unsigned types (uint*_t), to avoid false negatives.
```
uint32_t a;
if (a > =0) {...}
```
2. Excluding signed-cast comparisons to avoid false positives.
We will cast an unsigned int to a signed one and then compare it with zero to see if there is overflow, but Semgrep can not detect the type cast with a typed metavariable.
The following code raises an FP in the original rule with the pattern like `(size_t $E) >= 0`.
```
size_t a;
if ((int32_t) a >=0) {...}
```
PS: The above false positive seems like a bug in the Semgrep engine, but whatever, I set a whitelist pattern here to avoid such FP.