### PR TITLE
Add Dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    commit-message:
+      prefix: "actions"
+    schedule:
+      interval: weekly
+    groups:
+      actions-dependencies:
+        applies-to: version-updates
+        patterns:
+        - "*"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: true
           persist-credentials: false
@@ -43,7 +43,7 @@ jobs:
       - name: semgrep-test
         run: semgrep --test --test-ignore-todo
       - name: clone-semgrep-rules
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: semgrep/semgrep-rules
           path: tmp
@@ -60,7 +60,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - name: zizmor


### PR DESCRIPTION
Hi !

This small PR adds a Dependabot configuration file, to maintain GitHub Actions up-to-date. The current schedule is to check on a weekly basis, and to group updates in a single PR to reduce noise and workload for maintainers.